### PR TITLE
Prise en compte des users "local" pour la restriction de publication par profil

### DIFF
--- a/WebContent/WEB-INF/views/myspace/myspace_home.jsp
+++ b/WebContent/WEB-INF/views/myspace/myspace_home.jsp
@@ -67,7 +67,7 @@
 	    	<div class=btnMyspace>
  
                 <!-- check if publisher ldap profile can publish -->
-                <c:if test="${((fn:contains(publisherLdapProfiles,user.profile)) and (fn:length(user.profile)>0)) or (publisherLdapProfiles=='all') or (fn:length(publisherLdapProfiles)==0)}">
+                <c:if test="${((fn:contains(publisherLdapProfiles,user.profile)) and (fn:length(user.profile)>0)) or (publisherLdapProfiles=='all') or (fn:length(publisherLdapProfiles)==0) or ((fn:contains(publisherLdapProfiles,user.type)) and user != null)}">
 		    		<div class="btnUpload">
 		    			<a href="<c:url value="./myspace_upload" />" title="<fmt:message key="upload"/>" ><fmt:message key="upload"/></a>
 		    		</div>

--- a/WebContent/WEB-INF/views/myspace/myspace_uploadpage.jsp
+++ b/WebContent/WEB-INF/views/myspace/myspace_uploadpage.jsp
@@ -105,7 +105,7 @@
 
 	  	 	<!-- check if publisher ldap profile can publish -->
             <c:choose>
-            	<c:when test="${((fn:contains(publisherLdapProfiles,user.profile)) and (fn:length(user.profile)>0)) or (publisherLdapProfiles=='all') or (fn:length(publisherLdapProfiles)==0)}">
+            	<c:when test="${((fn:contains(publisherLdapProfiles,user.profile)) and (fn:length(user.profile)>0)) or (publisherLdapProfiles=='all') or (fn:length(publisherLdapProfiles)==0) or ((fn:contains(publisherLdapProfiles,user.type)) and user != null)}">
 
 			    	<c:if test="${pubTest == true}">
 			    		<div class="divCenter">
@@ -315,7 +315,14 @@
 				</c:when>
 				<c:otherwise>
 					<div class="divCenter">
-						<p><fmt:message key="restrictionprofil1"/></p>
+						<c:choose>
+							<c:when test="${user != null}">
+								<p><fmt:message key="restrictionprofil1"/></p>
+							</c:when>
+							<c:otherwise>
+								<p><fmt:message key="restrictionprofil2"/></p>
+							</c:otherwise>
+						</c:choose>
 					</div>
 				</c:otherwise>
 			</c:choose>

--- a/WebContent/WEB-INF/views/publication.jsp
+++ b/WebContent/WEB-INF/views/publication.jsp
@@ -128,7 +128,7 @@
 
 			<!-- check if publisher ldap profile can publish -->
 	        <c:choose>
-				<c:when test="${((fn:contains(publisherLdapProfiles,user.profile)) and (fn:length(user.profile)>0)) or (publisherLdapProfiles=='all') or (fn:length(publisherLdapProfiles)==0)}">
+				<c:when test="${((fn:contains(publisherLdapProfiles,user.profile)) and (fn:length(user.profile)>0)) or (publisherLdapProfiles=='all') or (fn:length(publisherLdapProfiles)==0) or ((fn:contains(publisherLdapProfiles,user.type)) and user != null)}">
 					<!-- FORMULAIRE -->
 			    	<form action="<c:url value="./publication_validatepublication"/>" method="POST">
 			    		

--- a/WebContent/WEB-INF/views/publication.jsp
+++ b/WebContent/WEB-INF/views/publication.jsp
@@ -48,11 +48,9 @@
 	    	
 	    	<br>
 	    	
-	    	<c:if test="${publication_type == 'serverCas'}">
-	       		<c:set var="borderstyleCas" value="border:2px dotted red;" />
-	    	</c:if>
-	    	<!-- check if publisher ldap profile can publish -->
-	        <c:if test="${((fn:contains(publisherLdapProfiles,user.profile)) and (fn:length(user.profile)>0)) or (publisherLdapProfiles=='all') or (fn:length(publisherLdapProfiles)==0)}">
+		    	<c:if test="${publication_type == 'serverCas'}">
+		       		<c:set var="borderstyleCas" value="border:2px dotted red;" />
+		    	</c:if>
 		    	<c:if test="${publication_type == 'serverFree' and pubFree == true}">
 		    	 	<c:set var="borderstyleFree" value="border:2px dotted red;" />
 		    	</c:if>
@@ -62,15 +60,17 @@
 		    	<c:if test="${publication_type == 'serverLocal'}">
 		       		<c:set var="borderstyleLocal" value="border:2px dotted red;" />
 		    	</c:if>
-			</c:if>
 
 		    	<!-- Choose if you have an account or not -->
 		    	<div class="pubLinks">
 		    		<div class="divPubCas" style="${borderstyleCas}">
 		    			<a class="linkPubCas" href="./authentication_cas?returnPage=publication"><fmt:message key="udsAccount"/> ${univAcronym}</a>
 		    		</div>
+		    		<div class="divPubLocal" style="${borderstyleLocal}">
+		    			<a class="linkPubLocal" href="./authentication_local?returnPage=publication"><fmt:message key="authLocalLink"/></a>
+		    		</div> 
 			    	<!-- check if publisher ldap profile can publish -->
-		            <c:if test="${((fn:contains(publisherLdapProfiles,user.profile)) and (fn:length(user.profile)>0)) or (publisherLdapProfiles=='all') or (fn:length(publisherLdapProfiles)==0)}">
+		            <c:if test="${((fn:contains(publisherLdapProfiles,user.profile)) and (fn:length(user.profile)>0)) or (publisherLdapProfiles=='all') or (fn:length(publisherLdapProfiles)==0) or ((fn:contains(publisherLdapProfiles,user.type)) and user != null)}">
 			    		<c:if test="${pubFree == true}">
 			    			<div class="divPubFree" style="${borderstyleFree}">
 			    				<a class="linkPubFree" href="./publication?publication_type=serverFree"><fmt:message key="free"/></a>
@@ -81,9 +81,6 @@
 			    				<a class="linkPubTest" href="./publication?publication_type=serverTest"><fmt:message key="test"/></a>
 			    			</div>
 			    		</c:if>
-			    		<div class="divPubLocal" style="${borderstyleLocal}">
-			    			<a class="linkPubLocal" href="./authentication_local?returnPage=publication"><fmt:message key="authLocalLink"/></a>
-			    		</div> 
 			    	</c:if>
 		    	</div>
 		    	
@@ -306,7 +303,14 @@
 				</c:when>
 				<c:otherwise>
 					<div class="divCenter">
-						<p><fmt:message key="restrictionprofil1"/></p>
+						<c:choose>
+							<c:when test="${user != null and ((publication_type == 'serverCas') or (publication_type == 'serverLocal'))}">
+								<p><fmt:message key="restrictionprofil1"/></p>
+							</c:when>
+							<c:otherwise>
+								<p><fmt:message key="restrictionprofil2"/></p>
+							</c:otherwise>
+						</c:choose>
 					</div>
 				</c:otherwise>
 			</c:choose>

--- a/src/org/ulpmm/univrav/language/messages_en.properties
+++ b/src/org/ulpmm/univrav/language/messages_en.properties
@@ -488,7 +488,7 @@ free=Free
 test=Test
 
 #: publication
-publicationmessage1=Before completing this form, please indicate if you have an external account or an account
+publicationmessage1=Before completing the publication form, please indicate if you have an external account or an account
 
 #: uploadpage.jsp
 publicationmessage2=If the recording is a test, you can use the access code "suppression" or click on the "Test" button.
@@ -501,6 +501,7 @@ publicationmessage4=At midnight, it will be deleted automatically.
 
 #: uploadpage.jsp, publication.jsp
 restrictionprofil1=Your profil doesn't allow you to publish.
+restrictionprofil2=Select a type of account and if not yet, please authenticate.
 
 #: publication
 level=Level

--- a/src/org/ulpmm/univrav/language/messages_fr.properties
+++ b/src/org/ulpmm/univrav/language/messages_fr.properties
@@ -487,7 +487,7 @@ free=Libre
 test=Test
 
 #: publication.jsp
-publicationmessage1=Avant de remplir ce formulaire, veuillez indiquer si vous avez un compte externe ou un compte
+publicationmessage1=Avant de remplir le formulaire de publication, veuillez indiquer si vous avez un compte externe ou un compte
 
 #: uploadpage.jsp
 publicationmessage2=Si l'enregistrement est un test, vous pouvez utiliser le code d'accès "suppression" ou cliquer sur le bouton "Test". 
@@ -500,6 +500,7 @@ publicationmessage4=A minuit, il sera effacé automatiquement.
 
 #: uploadpage.jsp, publication.jsp
 restrictionprofil1=Votre profil ne vous permet pas de publier.
+restrictionprofil2=Sélectionnez un type de compte et si ce n'est pas déjà fait, authentifiez-vous.
 
 #: publication
 level=Niveau


### PR DESCRIPTION
Désormais, si l'on ajoute "local" à la liste des publisherLdapProfiles dans univrav.properties, les users locaux auront accès à la publication. 

Par ailleurs, quelques phrases ont été changées pour améliorer la compréhension par l'utilisateur au moment de la publication : "Votre profil ne vous permet pas de publier" n'est affiché que si la personne s'est authentifiée et n'a pas le droit de publication, sinon s'affiche "Sélectionnez un type de compte et si ce n'est pas déjà fait, authentifiez-vous."
